### PR TITLE
Updates from another repo 7

### DIFF
--- a/src/routes/attachments/create.js
+++ b/src/routes/attachments/create.js
@@ -115,7 +115,9 @@ module.exports = [
         // retrieve download url for the response
         req.log.debug('retrieving download url');
         return httpClient.post(`${fileServiceUrl}downloadurl`, {
-          filePath,
+          param: {
+            filePath,
+          },
         });
       }
       return Promise.resolve();


### PR DESCRIPTION
Restoring non v5 call to file service because file service is yet to receive the v5 standards.