### PR TITLE
[HOTFIX] [DEV] fix: return all members and invites from ES

### DIFF
--- a/src/routes/projectMemberInvites/list.js
+++ b/src/routes/projectMemberInvites/list.js
@@ -42,7 +42,14 @@ module.exports = [
               },
             },
           },
-          inner_hits: {},
+          inner_hits: {
+            // TODO: replace this temporary fix with a better solution
+            // we have to get all the members of the project,
+            // should we just get a project object instead of creating such a detailed request?
+            // I guess just retrieving project by id and after returning members from it
+            // should work much faster
+            size: 1000,
+          },
         },
       },
     })

--- a/src/routes/projectMembers/list.js
+++ b/src/routes/projectMembers/list.js
@@ -57,7 +57,14 @@ module.exports = [
               },
             },
           },
-          inner_hits: {},
+          inner_hits: {
+            // TODO: replace this temporary fix with a better solution
+            // we have to get all the members of the project,
+            // should we just get a project object instead of creating such a detailed request?
+            // I guess just retrieving project by id and after returning members from it
+            // should work much faster
+            size: 1000,
+          },
         },
       },
     })


### PR DESCRIPTION
Without this fix, endpoints for getting a list of members and invites, return only 3 records.